### PR TITLE
Fix string process

### DIFF
--- a/Bve5_Parsing/MapGrammar/AstNodes/MapElement/PreTrain.cs
+++ b/Bve5_Parsing/MapGrammar/AstNodes/MapElement/PreTrain.cs
@@ -1,5 +1,7 @@
-﻿using Irony.Ast;
+﻿using Irony;
+using Irony.Ast;
 using Irony.Parsing;
+using System.Text.RegularExpressions;
 
 namespace Bve5_Parsing.MapGrammar.AstNodes.PreTrain
 {
@@ -18,12 +20,31 @@ namespace Bve5_Parsing.MapGrammar.AstNodes.PreTrain
             ParseTreeNodeList nodes = treeNode.GetMappedChildNodes();
 
             //引数の登録
-            if(nodes.Count > 3)
+            //形式が特殊なため、正規表現を利用して登録する
+            ExprNode expr = (ExprNode)nodes[2].AstNode;
+
+            Regex r = new Regex(@"(\d{1,2}):(\d{1,2}):(\d{1,2})");
+            Match m = r.Match(expr.Value.ToString());
+            if (m.Success)
             {
-                //hh:mm:ss TODO
-                AddArguments("hh", nodes, 2, typeof(double));
-                AddArguments("mm", nodes, 3, typeof(double));
-                AddArguments("ss", nodes, 4, typeof(double));
+                //hh:mm:ss
+                int hh = int.Parse(m.Groups[1].Value);
+                int mm = int.Parse(m.Groups[2].Value);
+                int ss = int.Parse(m.Groups[3].Value);
+                AddChild("hh:" + hh + "mm:" + mm + "ss:" + ss, nodes[0]);
+
+                //フォーマットの確認
+                if(hh >= 0 && hh < 25 && mm >= 0 && mm < 60 && ss >= 0 && ss < 60)
+                {
+                    Data.Arguments.Add("hh", hh);
+                    Data.Arguments.Add("mm", mm);
+                    Data.Arguments.Add("ss", ss);
+                }
+                else
+                {
+                    LogMessage logMessage = new LogMessage(ErrorLevel.Error, this.Location, "引数に与えられたフォーマットが不正です。:" + hh + ":" + mm + ":" + ss, Context.Language.ParserData.States[Context.Language.ParserData.States.Count - 1]);
+                    Context.Messages.Add(logMessage);
+                }
             }
             else
             {

--- a/Bve5_Parsing/MapGrammar/AstNodes/MapElementNodes.cs
+++ b/Bve5_Parsing/MapGrammar/AstNodes/MapElementNodes.cs
@@ -220,7 +220,8 @@ namespace Bve5_Parsing.MapGrammar.AstNodes
             //引数の登録
             AddArguments("mapPath", nodes, 1, typeof(string));
 
-            string filePath = nodes[1].Token.Value.ToString();
+            IdentifierKeyNode idenKey = (IdentifierKeyNode)nodes[1].AstNode;
+            string filePath = idenKey.Value;
             if (System.IO.File.Exists(filePath))
             {
                 //ファイル読み込み

--- a/Bve5_Parsing/MapGrammar/MapGrammar.cs
+++ b/Bve5_Parsing/MapGrammar/MapGrammar.cs
@@ -4,7 +4,7 @@ using Bve5_Parsing.MapGrammar.AstNodes;
 
 namespace Bve5_Parsing.MapGrammar
 {
-    [Language("MapGrammar", "0.1", "Bve5.7 Map file grammar.")]
+    [Language("MapGrammar", "0.2", "Bve5.7 Map file grammar.")]
     class MapGrammar : InterpretedLanguageGrammar
     {
         public MapGrammar() : base(false)

--- a/Bve5_Parsing/MapGrammar/MapGrammar.cs
+++ b/Bve5_Parsing/MapGrammar/MapGrammar.cs
@@ -405,8 +405,7 @@ namespace Bve5_Parsing.MapGrammar
             #region 先行列車
             preTrain.Rule = preTrain_pass;
             preTrain_pass.Rule =
-                  PreferShiftHere() + "PreTrain" + dot + "Pass" + "(" + "'" + expr + ":" + expr + ":" + expr + "'" + ")"
-                | PreferShiftHere() + "PreTrain" + dot + "Pass" + "(" + nullableExpr + ")";
+                  PreferShiftHere() + "PreTrain" + dot + "Pass" + "(" + expr + ")";
             #endregion 先行列車
 
             #region 光源

--- a/Bve5_Parsing/MapGrammar/MapGrammar.cs
+++ b/Bve5_Parsing/MapGrammar/MapGrammar.cs
@@ -474,9 +474,7 @@ namespace Bve5_Parsing.MapGrammar
             train.Rule = train_add | train_load | train_enable | train_stop;
             train_add.Rule = PreferShiftHere() + "Train" + dot + "Add" + "(" + rawKey + comma + identifierKey + comma + identifierKey + comma + nullableExpr + ")";
             train_load.Rule = PreferShiftHere() + "Train" + ToTerm("[") + identifierKey + ToTerm("]") + dot + "Load" + "(" + identifierKey + comma + identifierKey + comma + nullableExpr + ")";
-            train_enable.Rule =
-                  PreferShiftHere() + "Train" + ToTerm("[") + identifierKey + ToTerm("]") + dot + "Enable" + "(" + "'" + expr + ":" + expr + ":" + expr + "'" + ")"
-                | PreferShiftHere() + "Train" + ToTerm("[") + identifierKey + ToTerm("]") + dot + "Enable" + "(" + nullableExpr + ")";
+            train_enable.Rule = PreferShiftHere() + "Train" + ToTerm("[") + identifierKey + ToTerm("]") + dot + "Enable" + "(" + expr + ")";
             train_stop.Rule = PreferShiftHere() + "Train" + ToTerm("[") + identifierKey + ToTerm("]") + dot + "Stop" + "(" + nullableExpr + comma + nullableExpr + comma + nullableExpr + comma + nullableExpr + ")";
             #endregion 他列車
 

--- a/Bve5_Parsing/Properties/AssemblyInfo.cs
+++ b/Bve5_Parsing/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.*")]
+[assembly: AssemblyVersion("0.2.*")]


### PR DESCRIPTION
文字列の処理関係のバグをいくつか修正。

* include構文のファイルパスを文字列許可数式に変更。
* PreTrain.PassとTrain.Enable構文の引数の処理は上手く動かなかったので、正規表現を利用した独自処理に変更。