### PR TITLE
Change type determination -> TODO #6

### DIFF
--- a/Bve5_Parsing/MapGrammar/AstNodes/ExprNodes.cs
+++ b/Bve5_Parsing/MapGrammar/AstNodes/ExprNodes.cs
@@ -1,4 +1,5 @@
 ﻿
+using Irony;
 using Irony.Ast;
 using Irony.Interpreter;
 using Irony.Interpreter.Ast;
@@ -51,7 +52,10 @@ namespace Bve5_Parsing.MapGrammar.AstNodes
                 {
                     //文字列の結合
                     if (op != "+")
-                        throw new ScriptException("数式が不正です。", new NotFiniteNumberException(), this.Location, null);
+                    {
+                        LogMessage logMessage = new LogMessage(ErrorLevel.Error, this.Location, "演算子が不正です。文字列の演算は\'+\'演算子のみ利用できます。", context.Language.ParserData.States[context.Language.ParserData.States.Count - 1]);
+                        context.Messages.Add(logMessage);
+                    }
                     Value = val1.ToString() + val2.ToString();
                 }
                 else

--- a/Bve5_Parsing/MapGrammar/AstNodes/KeyNodes.cs
+++ b/Bve5_Parsing/MapGrammar/AstNodes/KeyNodes.cs
@@ -34,10 +34,11 @@ namespace Bve5_Parsing.MapGrammar.AstNodes
             base.Init(context, treeNode);
             ParseTreeNodeList nodes = treeNode.GetMappedChildNodes();
 
-            if (nodes[0].ToString().Equals("Var"))
+            object node = nodes[0].AstNode;
+            if (node.GetType() == typeof(VarNode))
             {
                 //変数
-                VarNode varNode = (VarNode)nodes[0].AstNode;
+                VarNode varNode = (VarNode)node;
                 Vars vars = Vars.GetInstance();
                 Value = vars.GetVar(varNode.Name).ToString();
                 AddChild(varNode.Name + ":" + Value, nodes[0]);

--- a/Bve5_Parsing/MapGrammar/AstNodes/MapElementNodes.cs
+++ b/Bve5_Parsing/MapGrammar/AstNodes/MapElementNodes.cs
@@ -74,63 +74,68 @@ namespace Bve5_Parsing.MapGrammar.AstNodes
         /// <param name="type">引数に指定する型(Optional)</param>
         protected void AddArguments(string argName, ParseTreeNodeList nodes, int idx, System.Type type = null)
         {
-            if (nodes.Count > idx)
-            {
-                object val;
-                if (nodes[idx].ToString().Equals("Expr"))
-                {
-                    //引数が数式
-                    ExprNode expr = (ExprNode)nodes[idx].AstNode;
-                    val = expr.Value;
-                    AddChild(argName + "=" + expr.Value, nodes[idx]);
-                }
-                else if (nodes[idx].ToString().Equals("NullableExpr"))
-                {
-                    //null許容数式
-                    NullableExprNode expr = (NullableExprNode)nodes[idx].AstNode;
-                    val = expr.Value;
-                    AddChild(argName + "=" + expr.Value, nodes[idx]);
-                }
-                else if (nodes[idx].AstNode.GetType() == typeof(IdentifierKeyNode))
-                {
-                    //IdenKey
-                    IdentifierKeyNode idenKey = (IdentifierKeyNode)nodes[idx].AstNode;
-                    val = idenKey.Value;
-                    AddChild(argName + "=" + idenKey.Value, nodes[idx]);
-                }
-                else if (nodes[idx].ToString().Equals("RawKey"))
-                {
-                    //RawKey
-                    RawKeyNode rawKey = (RawKeyNode)nodes[idx].AstNode;
-                    val = rawKey.Value;
-                    AddChild(argName + "=" + rawKey.Value, nodes[idx]);
-                }
-                else
-                {
-                    //引数がキー
-                    val = nodes[idx].Token.Value.ToString();
-                    AddChild(argName + "=" + nodes[idx].Token.Value, nodes[idx]);
-                }
+            object node = nodes[idx].AstNode;
+            object val;
 
-                //Dataに引数を登録する
-                if(type == null)
+            /*
+             * 引数の値を取得
+             */
+            if (node.GetType() == typeof(ExprNode))
+            {
+                //引数が数式
+                ExprNode expr = (ExprNode)node;
+                val = expr.Value;
+                AddChild(argName + "=" + expr.Value, nodes[idx]);
+            }
+            else if (node.GetType() == typeof(NullableExprNode))
+            {
+                //null許容数式
+                NullableExprNode expr = (NullableExprNode)node;
+                val = expr.Value;
+                AddChild(argName + "=" + expr.Value, nodes[idx]);
+            }
+            else if (node.GetType() == typeof(IdentifierKeyNode))
+            {
+                //IdenKey
+                IdentifierKeyNode idenKey = (IdentifierKeyNode)node;
+                val = idenKey.Value;
+                AddChild(argName + "=" + idenKey.Value, nodes[idx]);
+            }
+            else if (node.GetType() == typeof(RawKeyNode))
+            {
+                //RawKey
+                RawKeyNode rawKey = (RawKeyNode)node;
+                val = rawKey.Value;
+                AddChild(argName + "=" + rawKey.Value, nodes[idx]);
+            }
+            else
+            {
+                //引数がキー
+                val = nodes[idx].Token.Value.ToString();
+                AddChild(argName + "=" + nodes[idx].Token.Value, nodes[idx]);
+            }
+
+            /*
+             * 取得した値の登録
+             */
+            if (type == null)
+            {
+                //引数の型を無視して登録
+                Data.Arguments.Add(argName, val);
+            }
+            else
+            {
+                //引数の型に変換して登録
+                try
                 {
-                    //引数の型を無視して登録
-                    Data.Arguments.Add(argName, val);
+                    var v = System.Convert.ChangeType(val, type);
+                    Data.Arguments.Add(argName, v);
+
                 }
-                else
+                catch (System.FormatException e)
                 {
-                    try
-                    {
-                        var v = System.Convert.ChangeType(val, type);
-                        Data.Arguments.Add(argName, v);
-                        
-                    }
-                    catch(System.FormatException e)
-                    {
-                        LogMessage logMessage = new LogMessage(ErrorLevel.Error, this.Location, e.Message, Context.Language.ParserData.States[Context.Language.ParserData.States.Count - 1]);
-                        Context.Messages.Add(logMessage);
-                    }
+                    LogMessage logMessage = new LogMessage(ErrorLevel.Error, this.Location, e.Message, Context.Language.ParserData.States[Context.Language.ParserData.States.Count - 1]);
+                    Context.Messages.Add(logMessage);
                 }
             }
         }


### PR DESCRIPTION
保守性を考慮して、引数の取得時における型判定方法を、文字列比較からGetTypeとtypeofを利用した型比較に変更した。