### PR TITLE
[change] MapGrammarのエンコーディング定義を少し変更

### DIFF
--- a/Bve5_Parsing/MapGrammar/ANTLR_SyntaxDefinitions/MapGrammarLexer.g4
+++ b/Bve5_Parsing/MapGrammar/ANTLR_SyntaxDefinitions/MapGrammarLexer.g4
@@ -6,7 +6,7 @@ lexer grammar MapGrammarLexer;
 //ヘッダー
 BVETS : B V E T S;
 MAP : M A P;
-SELECT_ENCODE : ':' -> pushMode(ENCODING_MODE);
+ENCODING : [a-zA-Z0-9\-_]+;
 
 //インクルードディレクティブ
 INCLUDE : I N C L U D E;
@@ -158,8 +158,3 @@ QUOTE : '\'' -> pushMode(STRING_MODE) ;
 mode STRING_MODE;
 RQUOTE : '\'' -> popMode ;
 CHAR : . ;
-
-mode ENCODING_MODE;
-E_WS : [\t ]+ -> skip;
-HEADER_END : ('\r' '\n'? | '\n') -> popMode;
-ENCODE_CHAR : .;

--- a/Bve5_Parsing/MapGrammar/ANTLR_SyntaxDefinitions/MapGrammarParser.g4
+++ b/Bve5_Parsing/MapGrammar/ANTLR_SyntaxDefinitions/MapGrammarParser.g4
@@ -7,7 +7,7 @@ options{
 }
 
 root :
-	BVETS MAP version=NUM (SELECT_ENCODE encoding HEADER_END)? (statement STATE_END)* EOF
+	BVETS MAP version=NUM (COLON ENCODING?)? (statement STATE_END)* EOF
 	;
 
 statement :
@@ -279,12 +279,4 @@ string returns [string text]:
 
 string_text :
 	CHAR*
-	;
-
-encoding returns [string text]:
-	v=encode_string {$text = $v.text; }
-	;
-
-encode_string :
-	ENCODE_CHAR*
 	;

--- a/Bve5_Parsing/MapGrammar/AstNodes/BuildAstVisitor.cs
+++ b/Bve5_Parsing/MapGrammar/AstNodes/BuildAstVisitor.cs
@@ -21,8 +21,9 @@ namespace Bve5_Parsing.MapGrammar.AstNodes
         {
             var node = new RootNode();
             node.Version = context.version.Text;
-            if (context.encoding() != null) {
-                node.Encoding = context.encoding().text;
+
+            if (context.ENCODING() != null) {
+                node.Encoding = context.ENCODING().ToString();
             }
 
             foreach (var state in context.statement())


### PR DESCRIPTION
エンコーディング名の後に改行がない場合とコロンの後にエンコーディング名がない場合をサポート